### PR TITLE
Run yt-dlp sequentially

### DIFF
--- a/src/Downloader.cs
+++ b/src/Downloader.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Net;
+using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 
@@ -66,7 +67,7 @@ namespace YtDlpGuiApp
             }
         }
 
-        public static void RunYtDlp(string url, string downloadFolder, string formatArgs, string filenameTemplate, TextBox outputTextBox, Label progressLabel, ProgressBar bar)
+        public static Task RunYtDlp(string url, string downloadFolder, string formatArgs, string filenameTemplate, TextBox outputTextBox, Label progressLabel, ProgressBar bar)
         {
             string sanitizedFilename = Regex.Replace(filenameTemplate, "[\\/:*?\"<>|]", "_");
             string outputTemplate = Path.Combine(downloadFolder, sanitizedFilename);
@@ -82,12 +83,14 @@ namespace YtDlpGuiApp
                 CreateNoWindow = true
             };
 
-            var process = new Process { StartInfo = psi };
+            var process = new Process { StartInfo = psi, EnableRaisingEvents = true };
             process.OutputDataReceived += (s, e) => Helpers.AppendOutputSafe(e.Data, outputTextBox, progressLabel, bar);
             process.ErrorDataReceived += (s, e) => Helpers.AppendOutputSafe(e.Data, outputTextBox, progressLabel, bar);
             process.Start();
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
+
+            return process.WaitForExitAsync();
         }
     }
 }

--- a/src/MainForm.cs
+++ b/src/MainForm.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace YtDlpGuiApp
@@ -40,7 +41,7 @@ namespace YtDlpGuiApp
             folderDisplayLabel = new Label { Top = 115, Left = 10, Height = 25, Text = "", AutoEllipsis = true, Anchor = AnchorStyles.Left | AnchorStyles.Right, Width = ClientSize.Width - 20 };
 
             downloadButton = new Button { Text = "Download", Top = 150, Left = 10, Height = 40, Anchor = AnchorStyles.Left | AnchorStyles.Right, Width = ClientSize.Width - 20 };
-            downloadButton.Click += (s, e) => StartDownload();
+            downloadButton.Click += async (s, e) => await StartDownload();
 
             outputTextBox = new TextBox { Multiline = true, ScrollBars = ScrollBars.Vertical, Height = 280, Top = 200, Left = 10, Font = new Font("Consolas", 11), Anchor = AnchorStyles.Left | AnchorStyles.Right, Width = ClientSize.Width - 20 };
 
@@ -92,10 +93,10 @@ namespace YtDlpGuiApp
             }
         }
 
-        private void StartDownload()
+        private async Task StartDownload()
         {
             outputTextBox.Clear();
-            downloadProgressLabel.Text = "";
+            downloadProgressLabel.Text = string.Empty;
             progressBar.Value = 0;
 
             string[] urls = urlTextBox.Text.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries);
@@ -127,7 +128,9 @@ namespace YtDlpGuiApp
                     ? includeChannelCheckbox.Checked ? "%(title)s [%(uploader)s].mp3" : "%(title)s.mp3"
                     : includeChannelCheckbox.Checked ? "%(title)s [%(uploader)s].mp4" : "%(title)s.mp4";
 
-                Downloader.RunYtDlp(cleanUrl, downloadFolder, formatArgs, filenameTemplate, outputTextBox, downloadProgressLabel, progressBar);
+                progressBar.Value = 0;
+                downloadProgressLabel.Text = string.Empty;
+                await Downloader.RunYtDlp(cleanUrl, downloadFolder, formatArgs, filenameTemplate, outputTextBox, downloadProgressLabel, progressBar);
             }
         }
     }


### PR DESCRIPTION
## Summary
- make `RunYtDlp` return a Task and wait on process exit
- allow the download button to await each call
- reset progress UI before each download

## Testing
- `dotnet build -c Release src/YtDlpGuiApp.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470b3061a48321b232cbda2072ed01